### PR TITLE
Fix deploy script and added Factory to make deployment easier.

### DIFF
--- a/contracts/RealEstateToken.sol
+++ b/contracts/RealEstateToken.sol
@@ -30,7 +30,7 @@ contract RealEstateToken is ERC20, Ownable {
     /**
      * @notice The constructor for the Real Estate Token. This contract relates
      * to a unique real estate portfolio and each token minted is a share.
-     * @param _owner The owner of the contract
+     * @param _owner The address to receive all tokens on construction.
      * @param _supply The amount of tokens to mint on construction.
      */
     constructor(address _owner, uint256 _supply)

--- a/contracts/RealEstateToken.sol
+++ b/contracts/RealEstateToken.sol
@@ -39,12 +39,6 @@ contract RealEstateToken is ERC20, Ownable {
         _mint(_owner, _supply);
     }
 
-    // constructor( uint256 _supply)
-    //     public
-    // {
-    //     _mint(msg.sender, _supply);
-    // }
-
     /**
      * @notice Method to send Ether to this contract.
      */

--- a/contracts/RealEstateToken.sol
+++ b/contracts/RealEstateToken.sol
@@ -4,7 +4,6 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
-
 /**
  * @title Real Estate Token
  * @author Alberto Cuesta Canada
@@ -31,7 +30,7 @@ contract RealEstateToken is ERC20, Ownable {
     /**
      * @notice The constructor for the Real Estate Token. This contract relates
      * to a unique real estate portfolio and each token minted is a share.
-     * @param _owner The address to receive all tokens on construction.
+     * @param _owner The owner of the contract
      * @param _supply The amount of tokens to mint on construction.
      */
     constructor(address _owner, uint256 _supply)
@@ -39,6 +38,12 @@ contract RealEstateToken is ERC20, Ownable {
     {
         _mint(_owner, _supply);
     }
+
+    // constructor( uint256 _supply)
+    //     public
+    // {
+    //     _mint(msg.sender, _supply);
+    // }
 
     /**
      * @notice Method to send Ether to this contract.

--- a/contracts/RealEstateTokenFactory.sol
+++ b/contracts/RealEstateTokenFactory.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.5.0;
+
+import "./RealEstateToken.sol";
+
+contract RealEstateTokenFactory {
+    address[] public deployedRealEstateTokens;
+
+    function createRealEstateToken(uint _supply) public {
+        RealEstateToken newRealEstateToken = 
+        new RealEstateToken(msg.sender,_supply);
+        deployedRealEstateTokens.push(address(newRealEstateToken));
+    }
+
+    function getDeployedRealEstateTokens() 
+    public view returns (address[] memory) {
+        return deployedRealEstateTokens;
+    }
+}

--- a/contracts/RealEstateTokenFactory.sol
+++ b/contracts/RealEstateTokenFactory.sol
@@ -1,7 +1,11 @@
 pragma solidity ^0.5.0;
 
 import "./RealEstateToken.sol";
-
+/*
+* The factory is used to allow anyone to deploy a RealEstateToken instance
+* and become the owner without owning the source. This also makes the deployment easier as
+* the deploy script automatically assigns the deployer of the Factory as the owner of the * * RealEstateTokenInstance
+*/
 contract RealEstateTokenFactory {
     address[] public deployedRealEstateTokens;
 

--- a/contracts/RealEstateTokenFactory.sol
+++ b/contracts/RealEstateTokenFactory.sol
@@ -1,6 +1,8 @@
 pragma solidity ^0.5.0;
 
 import "./RealEstateToken.sol";
+
+
 /*
 * The factory is used to allow anyone to deploy a RealEstateToken instance
 * and become the owner without owning the source. This also makes the deployment easier as
@@ -10,12 +12,12 @@ contract RealEstateTokenFactory {
     address[] public deployedRealEstateTokens;
 
     function createRealEstateToken(uint _supply) public {
-        RealEstateToken newRealEstateToken = 
-        new RealEstateToken(msg.sender,_supply);
+        RealEstateToken newRealEstateToken = new RealEstateToken
+            (msg.sender,_supply);
         deployedRealEstateTokens.push(address(newRealEstateToken));
     }
 
-    function getDeployedRealEstateTokens() 
+    function getDeployedRealEstateTokens()
     public view returns (address[] memory) {
         return deployedRealEstateTokens;
     }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,7 @@
-const SimpleStorage = artifacts.require('./SimpleStorage.sol');
+const RealEstateTokenFactory = artifacts.require('./RealEstateTokenFactory.sol');
 
-module.exports = (deployer) => {
-    deployer.deploy(SimpleStorage);
+module.exports = async (deployer) => {
+    await deployer.deploy(RealEstateTokenFactory);
+    let instance = await RealEstateTokenFactory.deployed();
+    await instance.createRealEstateToken(1000);
 };

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -49,7 +49,7 @@ module.exports = {
         //
         development: {
             host: '127.0.0.1', // Localhost (default: none)
-            port: 7545, // Standard Ethereum port (default: none)
+            port: 8545, // Standard Ethereum port (default: none)
             network_id: '*', // Any network (default: none)
         },
 

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -49,7 +49,7 @@ module.exports = {
         //
         development: {
             host: '127.0.0.1', // Localhost (default: none)
-            port: 8545, // Standard Ethereum port (default: none)
+            port: 7545, // Standard Ethereum port (default: none)
             network_id: '*', // Any network (default: none)
         },
 


### PR DESCRIPTION
The deploy script was still referencing another contract.
Added the factory to avoid having to pass an address on deployment. The contract will now get the address from the deployer as an owner by default. It's also possible for others to create an instance an become an owner.